### PR TITLE
Add run-if-checksum-changed-script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # lets
+
 Simple CLI task runner
 
 Lets takes the best from Makefile and bash and presents you a simple yet powerful tool for defining and running cli tasks and commands.
@@ -7,11 +8,12 @@ Just describe your commands in `lets.yaml` and lets will do the rest.
 
 > Very alpha software. Things may and will change/break
 
-* [Install](#install)
-* [Usage](#usage)
-* [Config](#letsyaml)
-* [Build](#build)
-* [Completion](#completion)
+- [Install](#install)
+- [Usage](#usage)
+- [Config](#letsyaml)
+- [Build](#build)
+- [Completion](#completion)
+- [Useful scrips](#useful-sripts)
 
 ## Install
 
@@ -25,7 +27,7 @@ sudo curl -sfL https://raw.githubusercontent.com/lets-cli/lets/master/install.sh
 
 **Binary (Cross-platform)**:
 
-Download the version you need for your platform from [Lets Releases](https://github.com/lets-cli/lets/releases). 
+Download the version you need for your platform from [Lets Releases](https://github.com/lets-cli/lets/releases).
 
 Once downloaded, the binary can be run from anywhere.
 
@@ -54,21 +56,21 @@ yay -S lets-git
 
 ```yaml
 commands:
-    echo:
-      description: Echo text
-      cmd: |
-        echo "Hello"
-    
-    run:
-      description: Run some command
-      options: |
-        Usage: lets run [--debug] [--level=<level>]
-        
-        Options:
-          --debug, -d     Run with debug
-          --level=<level> Log level
-      cmd: |
-        env
+  echo:
+    description: Echo text
+    cmd: |
+      echo "Hello"
+
+  run:
+    description: Run some command
+    options: |
+      Usage: lets run [--debug] [--level=<level>]
+
+      Options:
+        --debug, -d     Run with debug
+        --level=<level> Log level
+    cmd: |
+      env
 ```
 
 3. Run commands
@@ -89,23 +91,23 @@ lets run --debug --level=info
 
 Config schema
 
-* [shell](#shell)
-* [mixins](#mixins)
-* [env](#global-env)
-* [eval_env](#global-eval_env)
-* [commands](#commands)
-    * [description](#description)
-    * [cmd](#cmd)
-    * [depends](#depends)
-    * [options](#options)
-    * [env](#env)
-    * [eval_env](#eval_env)
-    * [checksum](#checksum)
-
+- [shell](#shell)
+- [mixins](#mixins)
+- [env](#global-env)
+- [eval_env](#global-eval_env)
+- [commands](#commands)
+  - [description](#description)
+  - [cmd](#cmd)
+  - [depends](#depends)
+  - [options](#options)
+  - [env](#env)
+  - [eval_env](#eval_env)
+  - [checksum](#checksum)
 
 ### Top-level directives:
 
-#### `shell` 
+#### `shell`
+
 `key: shell`
 
 `type: string`
@@ -118,7 +120,8 @@ Example:
 shell: bash
 ```
 
-#### `global env` 
+#### `global env`
+
 `key: env`
 
 `type: string`
@@ -130,10 +133,11 @@ Example:
 ```yaml
 shell: bash
 env:
-    MY_GLOBAL_ENV: "123"
+  MY_GLOBAL_ENV: '123'
 ```
 
-#### `global eval_env` 
+#### `global eval_env`
+
 `key: env`
 
 `type: string`
@@ -145,10 +149,11 @@ Example:
 ```yaml
 shell: bash
 eval_env:
-    CURRENT_UID: echo "`id -u`:`id -g`"
+  CURRENT_UID: echo "`id -u`:`id -g`"
 ```
 
-#### `mixins` 
+#### `mixins`
+
 `key: mixins`
 
 `type: list of string`
@@ -161,25 +166,26 @@ Example:
 
 ```yaml
 # in lets.yaml
-...
+---
 shell: bash
 mixins:
-    - test.yaml
+  - test.yaml
 
 commands:
-    echo:
-        cmd: echo Hi
-    
+  echo:
+    cmd: echo Hi
+
 # in test.yaml
-...
+---
 commands:
-    test:
-        cmd: echo Testing...
+  test:
+    cmd: echo Testing...
 ```
 
 And `lets test` works fine.
 
 #### `commands`
+
 `key: commands`
 
 `type: mapping`
@@ -190,13 +196,14 @@ Example:
 
 ```yaml
 commands:
-    test:
-        description: Test something
+  test:
+    description: Test something
 ```
 
 ### Command directives:
 
 ##### `description`
+
 `key: description`
 
 `type: string`
@@ -207,56 +214,55 @@ Example:
 
 ```yaml
 commands:
-    test:
-        description: Test something
+  test:
+    description: Test something
 ```
 
 ##### `cmd`
+
 `key: cmd`
 
 `type: string or array of strings`
 
 Actual command to run in shell.
 
+You can access command name in your script, it stored in env var `LETS_CMD`
+
 Can be either a string (also a multiline string) or an array of strings.
 
-The main difference is that when specifying an array, all args, specified in terminal will be appended to cmd array 
+The main difference is that when specifying an array, all args, specified in terminal will be appended to cmd array
 
 Example single string:
 
 ```yaml
 commands:
-    test:
-        description: Test something
-        cmd: go test ./... -v
-
+  test:
+    description: Test something
+    cmd: go test ./... -v
 ```
-
 
 Example multiline string:
 
 ```yaml
 commands:
-    test:
-        description: Test something
-        cmd: |
-            echo "Running go tests..."
-            go test ./... -v
-
+  test:
+    description: Test something
+    cmd: |
+      echo "Running go tests..."
+      go test ./... -v
 ```
 
 Example array of strings:
 
 ```yaml
 commands:
-    test:
-        description: Test something
-        cmd: 
-            - go
-            - test
-            - ./...
+  test:
+    description: Test something
+    cmd:
+      - go
+      - test
+      - ./...
 ```
-
 
 When run with cmd as array of strings:
 
@@ -267,6 +273,7 @@ lets test -v
 the `-v` will be appended, so the resulting command to run will be `go test ./... -v`
 
 ##### `depends`
+
 `key: depends`
 
 `type: array of string`
@@ -278,25 +285,25 @@ Example:
 
 ```yaml
 commands:
-    build:
-        description: Build docker image
-        cmd: docker build -t myimg . -f Dockerfile
+  build:
+    description: Build docker image
+    cmd: docker build -t myimg . -f Dockerfile
 
-    test:
-        description: Test something
-        depends: [build]
-        cmd: go test ./... -v
+  test:
+    description: Test something
+    depends: [build]
+    cmd: go test ./... -v
 
-    fmt:
-        description: Format the code
-        depends: [build]
-        cmd: go fmt
+  fmt:
+    description: Format the code
+    depends: [build]
+    cmd: go fmt
 ```
 
 `build` command will be executed each time you run `lets test` or `lets fmt`
 
-
 ##### `options`
+
 `key: options`
 
 `type: string (multiline string)`
@@ -317,19 +324,17 @@ Lets see an example:
 
 ```yaml
 commands:
-    echo-env:
-        description: Echo env vars
-        options:
-            Usage: lets [--log-level=<level>] [--debug] <args>...
+  echo-env:
+    description: Echo env vars
+    options:
+      Usage: lets [--log-level=<level>] [--debug] <args>...
 
-            Options:
-                <args>...       List of required positional args
-                --log-level,-l      Log level
-                --debug,-d      Run with debug
-        cmd: |
-            echo ${LETSOPT_ARGS}
-            app ${LETSCLI_DEBUG}
-
+      Options: <args>...       List of required positional args
+        --log-level,-l      Log level
+        --debug,-d      Run with debug
+    cmd: |
+      echo ${LETSOPT_ARGS}
+      app ${LETSCLI_DEBUG}
 ```
 
 So here we have:
@@ -360,28 +365,28 @@ echo LETSCLI_LOG_LEVEL=${LETSCLI_LOG_LEVEL} # LETSCLI_LOG_LEVEL=--log-level info
 echo LETSCLI_DEBUG=${LETSCLI_DEBUG} # LETSCLI_DEBUG=--debug
 ```
 
-
 ##### `env`
+
 `key: env`
 
 `type: mapping string => string`
 
-Env is as simple as it sounds. Define additional env for a commmand: 
+Env is as simple as it sounds. Define additional env for a commmand:
 
 Example:
 
 ```yaml
 commands:
-    test:
-        description: Test something
-        env:
-            GO111MODULE: "on"
-            GOPROXY: https://goproxy.io
-        cmd: go build -o lets *.go
+  test:
+    description: Test something
+    env:
+      GO111MODULE: 'on'
+      GOPROXY: https://goproxy.io
+    cmd: go build -o lets *.go
 ```
 
-
 ##### `eval_env`
+
 `key: eval_env`
 
 `type: mapping string => string`
@@ -392,18 +397,18 @@ Example:
 
 ```yaml
 commands:
-    test:
-        description: Test something
-        eval_env:
-            CURRENT_UID: echo "`id -u`:`id -g`"
-            CURRENT_USER_NAME: echo "`id -un`"
-        cmd: go build -o lets *.go
+  test:
+    description: Test something
+    eval_env:
+      CURRENT_UID: echo "`id -u`:`id -g`"
+      CURRENT_USER_NAME: echo "`id -un`"
+    cmd: go build -o lets *.go
 ```
 
 Value will be executed in shell and result will be saved in env.
 
-
 ##### `checksum`
+
 `key: checksum`
 
 `type: array of string | mapping string => array of string`
@@ -412,14 +417,14 @@ Checksum used for computing file hashed. It is useful when you depend on some fi
 
 In `checksum` you can specify:
 
-- a list of file names 
+- a list of file names
 - a list of file regext patterns (parsed via go `path/filepath.Glob`)
 
 or
 
 - a mapping where key is name of env variable and value is:
-    - a list of file names 
-    - a list of file regext patterns (parsed via go `path/filepath.Glob`)
+  - a list of file names
+  - a list of file regext patterns (parsed via go `path/filepath.Glob`)
 
 Each time a command runs, `lets` will calculate the checksum of all files specified in `checksum`.
 
@@ -429,19 +434,19 @@ If checksum is a mapping, e.g:
 
 ```yaml
 commands:
-    build:
-    checksum:
-      deps:
-        - package.json
-      doc:
-        - Readme.md
+  build:
+  checksum:
+    deps:
+      - package.json
+    doc:
+      - Readme.md
 ```
 
 Resulting env will be:
 
-* `LETS_CHECKSUM_DEPS` - checksum of deps files
-* `LETS_CHECKSUM_DOC` - checksum of doc files
-* `LETS_CHECKSUM` - checksum of all checksums (deps and doc)
+- `LETS_CHECKSUM_DEPS` - checksum of deps files
+- `LETS_CHECKSUM_DOC` - checksum of doc files
+- `LETS_CHECKSUM` - checksum of all checksums (deps and doc)
 
 Checksum is calculated with `sha1`.
 
@@ -452,12 +457,12 @@ Example:
 ```yaml
 shell: bash
 commands:
-    app-build:
-        checksum: 
-            - requirements-*.txt
-        cmd: |
-            docker pull myrepo/app:${LETS_CHECKSUM}
-            docker run --rm myrepo/app${LETS_CHECKSUM} python -m app       
+  app-build:
+    checksum:
+      - requirements-*.txt
+    cmd: |
+      docker pull myrepo/app:${LETS_CHECKSUM}
+      docker run --rm myrepo/app${LETS_CHECKSUM} python -m app
 ```
 
 ## Build
@@ -478,10 +483,28 @@ go build -o lets *.go && sudo mv ./lets /usr/local/bin/lets
 
 You can use Bash/Zsh/Oh-My-Zsh completion in you terminal
 
-* **Bash**
+- **Bash**
 
-    Add `source <(lets completion -s bash)` to your `~/.bashrc` or `~/.bash_profile`
+  Add `source <(lets completion -s bash)` to your `~/.bashrc` or `~/.bash_profile`
 
-* **Zsh/Oh-My-Zsh**
+- **Zsh/Oh-My-Zsh**
 
-    There is a [repo](https://github.com/lets-cli/lets-zsh-plugin) with zsh plugin with instructions
+  There is a [repo](https://github.com/lets-cli/lets-zsh-plugin) with zsh plugin with instructions
+
+### Useful scrips
+
+You can use this bash scripts in your own `lets.yaml` in case, if you wish to implement some functionality, that does not implemented yet in Lets
+
+- run cmd only if checksum was changed:
+
+```yaml
+# lets.yaml
+cmd:
+  build:
+    cmd: scripts/run-if-checksum-changed.sh "docker build ."
+  #           |-------path to bash script------|---cmd to run---|
+  run:
+    depends:
+      - build
+    cmd: docker-compose up
+```

--- a/README.md
+++ b/README.md
@@ -493,16 +493,16 @@ You can use Bash/Zsh/Oh-My-Zsh completion in you terminal
 
 You can use this bash scripts in your own `lets.yaml` in case, if you wish to implement some functionality, that does not implemented yet in Lets
 
-- run cmd only if checksum was changed:
-
-```yaml
-# lets.yaml
-cmd:
-  build:
-    cmd: scripts/run-if-checksum-changed.sh "docker build ."
-  #           |-------path to bash script------|---cmd to run---|
-  run:
-    depends:
-      - build
-    cmd: docker-compose up
-```
+- run cmd only if checksum was changed
+    > Do't forget to add `.lets/` into your `.gitignore `
+    ```yaml
+    # lets.yaml
+    commands:
+      build:
+        cmd: scripts/run-if-checksum-changed.sh "docker build ."
+      #           |-------path to bash script------|---cmd to run---|
+      run:
+        depends:
+          - build
+        cmd: docker-compose up
+    ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # lets
-
 Simple CLI task runner
 
 Lets takes the best from Makefile and bash and presents you a simple yet powerful tool for defining and running cli tasks and commands.
@@ -8,12 +7,11 @@ Just describe your commands in `lets.yaml` and lets will do the rest.
 
 > Very alpha software. Things may and will change/break
 
-- [Install](#install)
-- [Usage](#usage)
-- [Config](#letsyaml)
-- [Build](#build)
-- [Completion](#completion)
-- [Useful scrips](#useful-sripts)
+* [Install](#install)
+* [Usage](#usage)
+* [Config](#letsyaml)
+* [Build](#build)
+* [Completion](#completion)
 
 ## Install
 
@@ -27,7 +25,7 @@ sudo curl -sfL https://raw.githubusercontent.com/lets-cli/lets/master/install.sh
 
 **Binary (Cross-platform)**:
 
-Download the version you need for your platform from [Lets Releases](https://github.com/lets-cli/lets/releases).
+Download the version you need for your platform from [Lets Releases](https://github.com/lets-cli/lets/releases). 
 
 Once downloaded, the binary can be run from anywhere.
 
@@ -56,21 +54,21 @@ yay -S lets-git
 
 ```yaml
 commands:
-  echo:
-    description: Echo text
-    cmd: |
-      echo "Hello"
-
-  run:
-    description: Run some command
-    options: |
-      Usage: lets run [--debug] [--level=<level>]
-
-      Options:
-        --debug, -d     Run with debug
-        --level=<level> Log level
-    cmd: |
-      env
+    echo:
+      description: Echo text
+      cmd: |
+        echo "Hello"
+    
+    run:
+      description: Run some command
+      options: |
+        Usage: lets run [--debug] [--level=<level>]
+        
+        Options:
+          --debug, -d     Run with debug
+          --level=<level> Log level
+      cmd: |
+        env
 ```
 
 3. Run commands
@@ -91,23 +89,23 @@ lets run --debug --level=info
 
 Config schema
 
-- [shell](#shell)
-- [mixins](#mixins)
-- [env](#global-env)
-- [eval_env](#global-eval_env)
-- [commands](#commands)
-  - [description](#description)
-  - [cmd](#cmd)
-  - [depends](#depends)
-  - [options](#options)
-  - [env](#env)
-  - [eval_env](#eval_env)
-  - [checksum](#checksum)
+* [shell](#shell)
+* [mixins](#mixins)
+* [env](#global-env)
+* [eval_env](#global-eval_env)
+* [commands](#commands)
+    * [description](#description)
+    * [cmd](#cmd)
+    * [depends](#depends)
+    * [options](#options)
+    * [env](#env)
+    * [eval_env](#eval_env)
+    * [checksum](#checksum)
+
 
 ### Top-level directives:
 
-#### `shell`
-
+#### `shell` 
 `key: shell`
 
 `type: string`
@@ -120,8 +118,7 @@ Example:
 shell: bash
 ```
 
-#### `global env`
-
+#### `global env` 
 `key: env`
 
 `type: string`
@@ -133,11 +130,10 @@ Example:
 ```yaml
 shell: bash
 env:
-  MY_GLOBAL_ENV: '123'
+    MY_GLOBAL_ENV: "123"
 ```
 
-#### `global eval_env`
-
+#### `global eval_env` 
 `key: env`
 
 `type: string`
@@ -149,11 +145,10 @@ Example:
 ```yaml
 shell: bash
 eval_env:
-  CURRENT_UID: echo "`id -u`:`id -g`"
+    CURRENT_UID: echo "`id -u`:`id -g`"
 ```
 
-#### `mixins`
-
+#### `mixins` 
 `key: mixins`
 
 `type: list of string`
@@ -166,26 +161,25 @@ Example:
 
 ```yaml
 # in lets.yaml
----
+...
 shell: bash
 mixins:
-  - test.yaml
+    - test.yaml
 
 commands:
-  echo:
-    cmd: echo Hi
-
+    echo:
+        cmd: echo Hi
+    
 # in test.yaml
----
+...
 commands:
-  test:
-    cmd: echo Testing...
+    test:
+        cmd: echo Testing...
 ```
 
 And `lets test` works fine.
 
 #### `commands`
-
 `key: commands`
 
 `type: mapping`
@@ -196,14 +190,13 @@ Example:
 
 ```yaml
 commands:
-  test:
-    description: Test something
+    test:
+        description: Test something
 ```
 
 ### Command directives:
 
 ##### `description`
-
 `key: description`
 
 `type: string`
@@ -214,8 +207,8 @@ Example:
 
 ```yaml
 commands:
-  test:
-    description: Test something
+    test:
+        description: Test something
 ```
 
 ##### `cmd`
@@ -230,39 +223,43 @@ You can access command name in your script, it stored in env var `LETS_CMD`
 
 Can be either a string (also a multiline string) or an array of strings.
 
-The main difference is that when specifying an array, all args, specified in terminal will be appended to cmd array
+The main difference is that when specifying an array, all args, specified in terminal will be appended to cmd array 
 
 Example single string:
 
 ```yaml
 commands:
-  test:
-    description: Test something
-    cmd: go test ./... -v
+    test:
+        description: Test something
+        cmd: go test ./... -v
+
 ```
+
 
 Example multiline string:
 
 ```yaml
 commands:
-  test:
-    description: Test something
-    cmd: |
-      echo "Running go tests..."
-      go test ./... -v
+    test:
+        description: Test something
+        cmd: |
+            echo "Running go tests..."
+            go test ./... -v
+
 ```
 
 Example array of strings:
 
 ```yaml
 commands:
-  test:
-    description: Test something
-    cmd:
-      - go
-      - test
-      - ./...
+    test:
+        description: Test something
+        cmd: 
+            - go
+            - test
+            - ./...
 ```
+
 
 When run with cmd as array of strings:
 
@@ -273,7 +270,6 @@ lets test -v
 the `-v` will be appended, so the resulting command to run will be `go test ./... -v`
 
 ##### `depends`
-
 `key: depends`
 
 `type: array of string`
@@ -285,25 +281,25 @@ Example:
 
 ```yaml
 commands:
-  build:
-    description: Build docker image
-    cmd: docker build -t myimg . -f Dockerfile
+    build:
+        description: Build docker image
+        cmd: docker build -t myimg . -f Dockerfile
 
-  test:
-    description: Test something
-    depends: [build]
-    cmd: go test ./... -v
+    test:
+        description: Test something
+        depends: [build]
+        cmd: go test ./... -v
 
-  fmt:
-    description: Format the code
-    depends: [build]
-    cmd: go fmt
+    fmt:
+        description: Format the code
+        depends: [build]
+        cmd: go fmt
 ```
 
 `build` command will be executed each time you run `lets test` or `lets fmt`
 
-##### `options`
 
+##### `options`
 `key: options`
 
 `type: string (multiline string)`
@@ -324,17 +320,19 @@ Lets see an example:
 
 ```yaml
 commands:
-  echo-env:
-    description: Echo env vars
-    options:
-      Usage: lets [--log-level=<level>] [--debug] <args>...
+    echo-env:
+        description: Echo env vars
+        options:
+            Usage: lets [--log-level=<level>] [--debug] <args>...
 
-      Options: <args>...       List of required positional args
-        --log-level,-l      Log level
-        --debug,-d      Run with debug
-    cmd: |
-      echo ${LETSOPT_ARGS}
-      app ${LETSCLI_DEBUG}
+            Options:
+                <args>...       List of required positional args
+                --log-level,-l      Log level
+                --debug,-d      Run with debug
+        cmd: |
+            echo ${LETSOPT_ARGS}
+            app ${LETSCLI_DEBUG}
+
 ```
 
 So here we have:
@@ -365,28 +363,28 @@ echo LETSCLI_LOG_LEVEL=${LETSCLI_LOG_LEVEL} # LETSCLI_LOG_LEVEL=--log-level info
 echo LETSCLI_DEBUG=${LETSCLI_DEBUG} # LETSCLI_DEBUG=--debug
 ```
 
-##### `env`
 
+##### `env`
 `key: env`
 
 `type: mapping string => string`
 
-Env is as simple as it sounds. Define additional env for a commmand:
+Env is as simple as it sounds. Define additional env for a commmand: 
 
 Example:
 
 ```yaml
 commands:
-  test:
-    description: Test something
-    env:
-      GO111MODULE: 'on'
-      GOPROXY: https://goproxy.io
-    cmd: go build -o lets *.go
+    test:
+        description: Test something
+        env:
+            GO111MODULE: "on"
+            GOPROXY: https://goproxy.io
+        cmd: go build -o lets *.go
 ```
 
-##### `eval_env`
 
+##### `eval_env`
 `key: eval_env`
 
 `type: mapping string => string`
@@ -397,18 +395,18 @@ Example:
 
 ```yaml
 commands:
-  test:
-    description: Test something
-    eval_env:
-      CURRENT_UID: echo "`id -u`:`id -g`"
-      CURRENT_USER_NAME: echo "`id -un`"
-    cmd: go build -o lets *.go
+    test:
+        description: Test something
+        eval_env:
+            CURRENT_UID: echo "`id -u`:`id -g`"
+            CURRENT_USER_NAME: echo "`id -un`"
+        cmd: go build -o lets *.go
 ```
 
 Value will be executed in shell and result will be saved in env.
 
-##### `checksum`
 
+##### `checksum`
 `key: checksum`
 
 `type: array of string | mapping string => array of string`
@@ -417,14 +415,14 @@ Checksum used for computing file hashed. It is useful when you depend on some fi
 
 In `checksum` you can specify:
 
-- a list of file names
+- a list of file names 
 - a list of file regext patterns (parsed via go `path/filepath.Glob`)
 
 or
 
 - a mapping where key is name of env variable and value is:
-  - a list of file names
-  - a list of file regext patterns (parsed via go `path/filepath.Glob`)
+    - a list of file names 
+    - a list of file regext patterns (parsed via go `path/filepath.Glob`)
 
 Each time a command runs, `lets` will calculate the checksum of all files specified in `checksum`.
 
@@ -434,19 +432,19 @@ If checksum is a mapping, e.g:
 
 ```yaml
 commands:
-  build:
-  checksum:
-    deps:
-      - package.json
-    doc:
-      - Readme.md
+    build:
+    checksum:
+      deps:
+        - package.json
+      doc:
+        - Readme.md
 ```
 
 Resulting env will be:
 
-- `LETS_CHECKSUM_DEPS` - checksum of deps files
-- `LETS_CHECKSUM_DOC` - checksum of doc files
-- `LETS_CHECKSUM` - checksum of all checksums (deps and doc)
+* `LETS_CHECKSUM_DEPS` - checksum of deps files
+* `LETS_CHECKSUM_DOC` - checksum of doc files
+* `LETS_CHECKSUM` - checksum of all checksums (deps and doc)
 
 Checksum is calculated with `sha1`.
 
@@ -457,12 +455,12 @@ Example:
 ```yaml
 shell: bash
 commands:
-  app-build:
-    checksum:
-      - requirements-*.txt
-    cmd: |
-      docker pull myrepo/app:${LETS_CHECKSUM}
-      docker run --rm myrepo/app${LETS_CHECKSUM} python -m app
+    app-build:
+        checksum: 
+            - requirements-*.txt
+        cmd: |
+            docker pull myrepo/app:${LETS_CHECKSUM}
+            docker run --rm myrepo/app${LETS_CHECKSUM} python -m app       
 ```
 
 ## Build
@@ -483,13 +481,13 @@ go build -o lets *.go && sudo mv ./lets /usr/local/bin/lets
 
 You can use Bash/Zsh/Oh-My-Zsh completion in you terminal
 
-- **Bash**
+* **Bash**
 
-  Add `source <(lets completion -s bash)` to your `~/.bashrc` or `~/.bash_profile`
+    Add `source <(lets completion -s bash)` to your `~/.bashrc` or `~/.bash_profile`
 
-- **Zsh/Oh-My-Zsh**
+* **Zsh/Oh-My-Zsh**
 
-  There is a [repo](https://github.com/lets-cli/lets-zsh-plugin) with zsh plugin with instructions
+    There is a [repo](https://github.com/lets-cli/lets-zsh-plugin) with zsh plugin with instructions
 
 ### Useful scrips
 

--- a/commands/run.go
+++ b/commands/run.go
@@ -112,7 +112,7 @@ func runCmd(cmdToRun command.Command, cfg *config.Config, out io.Writer, parentN
 		convertEnvMapToList(cmdToRun.CliOptions),
 		convertChecksumToEnvForCmd(cmdToRun.Checksum),
 		convertChecksumMapToEnvForCmd(cmdToRun.ChecksumMap),
-		makeEnvEntry("LETS_CMD", cmdToRun.name),
+		makeEnvEntry("LETS_CMD", cmdToRun.Name),
 	)
 	if !isChildCmd {
 		logging.Log.Debugf(

--- a/commands/run.go
+++ b/commands/run.go
@@ -2,14 +2,15 @@ package commands
 
 import (
 	"fmt"
-	"github.com/docopt/docopt-go"
-	"github.com/lets-cli/lets/commands/command"
-	"github.com/lets-cli/lets/config"
-	"github.com/lets-cli/lets/logging"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/docopt/docopt-go"
+	"github.com/lets-cli/lets/commands/command"
+	"github.com/lets-cli/lets/config"
+	"github.com/lets-cli/lets/logging"
 )
 
 const (
@@ -112,7 +113,7 @@ func runCmd(cmdToRun command.Command, cfg *config.Config, out io.Writer, parentN
 		convertEnvMapToList(cmdToRun.CliOptions),
 		convertChecksumToEnvForCmd(cmdToRun.Checksum),
 		convertChecksumMapToEnvForCmd(cmdToRun.ChecksumMap),
-		makeEnvEntry("LETS_CMD", cmdToRun.Name),
+		[]string{makeEnvEntry("LETS_CMD", cmdToRun.Name)},
 	)
 	if !isChildCmd {
 		logging.Log.Debugf(

--- a/commands/run.go
+++ b/commands/run.go
@@ -112,6 +112,7 @@ func runCmd(cmdToRun command.Command, cfg *config.Config, out io.Writer, parentN
 		convertEnvMapToList(cmdToRun.CliOptions),
 		convertChecksumToEnvForCmd(cmdToRun.Checksum),
 		convertChecksumMapToEnvForCmd(cmdToRun.ChecksumMap),
+		makeEnvEntry("LETS_CMD", cmdToRun.name)
 	)
 	if !isChildCmd {
 		logging.Log.Debugf(

--- a/commands/run.go
+++ b/commands/run.go
@@ -112,7 +112,7 @@ func runCmd(cmdToRun command.Command, cfg *config.Config, out io.Writer, parentN
 		convertEnvMapToList(cmdToRun.CliOptions),
 		convertChecksumToEnvForCmd(cmdToRun.Checksum),
 		convertChecksumMapToEnvForCmd(cmdToRun.ChecksumMap),
-		makeEnvEntry("LETS_CMD", cmdToRun.name)
+		makeEnvEntry("LETS_CMD", cmdToRun.name),
 	)
 	if !isChildCmd {
 		logging.Log.Debugf(

--- a/useful-scripts/run-if-checksum-changed.sh
+++ b/useful-scripts/run-if-checksum-changed.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+CMD=$1
+NEW_CHECKSUM=$LETS_CHECKSUM
+LABEL=$LETS_CMD
+LETS_DIR=.lets
+
+# ensure lets dir exists
+if [[ ! -d "$LETS_DIR" ]]; then
+    mkdir $LETS_DIR
+fi;
+# ensure checksum file exists
+if [[ ! -f "$LETS_DIR/$LABEL" ]]; then
+    touch $LETS_DIR/$LABEL
+fi;
+
+# read
+PREV_CHECKSUM=$(head -n 1 $LETS_DIR/$LABEL)
+
+if [[ "$NEW_CHECKSUM" != "$PREV_CHECKSUM" ]]; then
+    # update checksum
+    echo $NEW_CHECKSUM > $LETS_DIR/$LABEL
+    eval $CMD
+fi;


### PR DESCRIPTION
I noticed, that often I need to run some cmd only if smth were changed. For example, if I update my `package.json` file, I need to install new dependencies, before run any other command, using `Lets`. So, until it will be implemented in lets as standard behavior (see #32) we should use handwritten bash scripts. 
In this PR I wont to standardize this scripts and propose to store them in repo for future usage.

Also I added env variable LETS_CMD which stores name of the current command. It will be useful for logging and other stuff