### PR TITLE
Add required `shell` param to getting started example && fix link to config reference

### DIFF
--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -31,9 +31,11 @@ lets # it will use lets.yaml right here (at /home/me/project/lets.yaml)
 ## Creating new config
 
 1. Create `lets.yaml` file in your project directory
-2. Add commands to `lets.yaml` config. [Config reference](#letsyaml)
+2. Add commands to `lets.yaml` config. [Config reference](/docs/config)
 
 ```yaml
+shell: /bin/sh
+
 commands:
     echo:
       description: Echo text

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -31,7 +31,7 @@ lets # it will use lets.yaml right here (at /home/me/project/lets.yaml)
 ## Creating new config
 
 1. Create `lets.yaml` file in your project directory
-2. Add commands to `lets.yaml` config. [Config reference](/docs/config)
+2. Add commands to `lets.yaml` config. [Config reference](config.md)
 
 ```yaml
 shell: /bin/sh


### PR DESCRIPTION
1. Lets does not work without specified `shell` param.
Getting `[ERROR] failed to load config file lets.yaml: 'shell' field is required`
Line `shell: sh` is added to getting_started.md config example.

2. Fix for config reference in getting_started.md.(Not sure docusaurus can resolve it)