### PR TITLE
fix(aur): install to /usr/bin

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,10 +49,12 @@ aurs:
     license: "MIT"
     maintainers:
       - 'Kindritskiy Maksym <kindritskiy.m@gmail.com>'
+    contributors:
+      - "Luis Martinez <luis dot martinez at disroot dot org>"
     private_key: '{{ .Env.AUR_GITHUB_TOKEN }}'
     git_url: 'ssh://aur@aur.archlinux.org/lets-bin.git'
     package: |-
-      install -Dm755 "./lets-bin" "${pkgdir}/usr/local/bin/lets-bin"
+      install -Dm755 "./lets-bin" "${pkgdir}/usr/bin/lets"
     commit_author:
       name: 'Github Action Bot'
       email: kindritskiy.m@gmail.com


### PR DESCRIPTION
Arch packaging guidelines forbid installs to /usr/local, instead directing us to install to /usr.

[Reference](https://wiki.archlinux.org/title/Arch_package_guidelines#Package_etiquette)