### PR TITLE
support top level custom keywords starting with "x-"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.24-bookworm as builder
+FROM golang:1.24-bookworm AS builder
 
-ENV GOPROXY https://proxy.golang.org
-ENV CGO_ENABLED 1
+ENV GOPROXY=https://proxy.golang.org
+ENV CGO_ENABLED=1
 # disable all compiler errors
 ENV CGO_CFLAGS=-w
 
@@ -26,6 +26,6 @@ COPY go.sum .
 
 RUN go mod download
 
-FROM golangci/golangci-lint:v1.64.7-alpine as linter
+FROM golangci/golangci-lint:v1.64.7-alpine AS linter
 
 RUN mkdir -p /.cache && chmod -R 777 /.cache

--- a/config/config/config.go
+++ b/config/config/config.go
@@ -9,8 +9,20 @@ import (
 	"strings"
 
 	"github.com/lets-cli/lets/config/path"
+	"github.com/lets-cli/lets/set"
 	"github.com/lets-cli/lets/util"
 	"gopkg.in/yaml.v3"
+)
+
+var keywords = set.NewSet[string](
+	"version",
+	"shell",
+	"env",
+	"eval_env",
+	"init",
+	"before",
+	"mixins",
+	"commands",
 )
 
 // Config is a struct for loaded config file.
@@ -37,6 +49,18 @@ type Config struct {
 }
 
 func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var raw map[string]interface{}
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+
+	// check if config has unsupported keywords
+	for key := range raw {
+		if !keywords.Contains(key) && !strings.HasPrefix(key, "x-") {
+			return fmt.Errorf("keyword '%s' not supported", key)
+		}
+	}
+
 	var config struct {
 		Version  Version
 		Mixins   []*Mixin

--- a/config/config/env.go
+++ b/config/config/env.go
@@ -36,6 +36,17 @@ func (e *Envs) UnmarshalYAML(node *yaml.Node) error {
 		keyNode := node.Content[i]
 		valueNode := node.Content[i+1]
 
+		// handle <<: *aliased case
+		if keyNode.Tag == "!!merge" {
+			aliasedEnv := &Envs{}
+			err := aliasedEnv.UnmarshalYAML(valueNode.Alias)
+			if err != nil {
+				return errors.New("lets: can not parse aliased env")
+			}
+			e.Merge(aliasedEnv)
+			continue
+		}
+
 		envAsStr := ""
 
 		if err := valueNode.Decode(&envAsStr); err == nil {

--- a/docs/docs/best_practices.md
+++ b/docs/docs/best_practices.md
@@ -5,7 +5,7 @@ title: Best practices
 
 ### Naming conventions
 
-Prefer single word over plural. 
+Prefer single word over plural.
 
 It is better to leverage semantics of `lets` as an intention to do something. For example it is natural saying `lets test` or `lets build` something.
 
@@ -106,3 +106,28 @@ As you can see, we execute `build` command each time we execute `run` command (`
 
 `persist_checksum` will save calculated checksum to `.lets` directory and all subsequent calls of `build` command will
 read checksum from disk, calculate new checksum, and compare them. If `package.json` will change - we will rebuild the image.
+
+
+### Initialize project using `init`
+
+You can use `init` keyword to write a script that will do some initialization on lets startup, like creating some dirs, configs or installing project dependencies.
+
+By default, `init` runs each time the `lets` program is executed.
+
+You can make `init` conditional, by simply creating a file and checking if it exists at the start of `init` script.
+
+Example:
+
+```
+shell: bash
+
+init: |
+  if [[ ! -f .lets/init_done ]]; then
+    echo "calling init script"
+    touch .lets/init_done
+  fi
+```
+
+In this example we are checking for `.lets/init_done` file existence. If it does not exist, we will call init script and create `init_done` file as a marker of successfull init script invocation.
+
+We are using `.lets` dir here because this dir will be created by `lets` itself and is generally a good place to create such files, but you are free to create files with any name and in any directory you want.

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -6,6 +6,9 @@ title: Changelog
 ## [Unreleased](https://github.com/lets-cli/lets/releases/tag/v0.0.X)
 
 * `[Dependency]` update go to `1.24`
+* `[Added]` support custom top-level keywords that start with `x-`
+* `[Added]` check for invalid top-level keywords during config parsing
+* `[Added]` support YAML aliases in `env` - env will be merged aliases mapping
 
 ## [0.0.55](https://github.com/lets-cli/lets/releases/tag/v0.0.55)
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -1,31 +1,92 @@
 module.exports = {
-  someSidebar: {
-    "Introduction": [
-      'what_is_lets',
-      'installation',
-      'quick_start',
-      'completion',
-    ],
-    "Usage": [
-      'basic_usage',
-      'advanced_usage',
-    ],
-    "Config format": ['config'],
-    "Api Reference": [
-      'cli',
-      'env',
-    ],
-    "Examples": [
-      'examples',
-      'example_js',
-    ],
-    "Best practices": ['best_practices'],
-    Changelog: ['changelog'],
-    "IDE support": ['ide_support'],
-    Development: [
-      'architecture',
-      'development',
-      'contribute'
-    ],
-  },
+  mySidebar: [
+    {
+      type: 'category',
+      label: 'Introduction',
+      collapsed: false,
+      items: [
+        {
+          type: 'doc',
+          id: 'what_is_lets',
+        },
+        {
+          type: 'doc',
+          id: 'installation',
+        },
+        {
+          type: 'doc',
+          id: 'quick_start',
+        },
+        {
+          type: 'doc',
+          id: 'completion',
+        },
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Usage',
+      items: [
+        {
+          type: 'doc',
+          id: 'basic_usage',
+        },
+        {
+          type: 'doc',
+          id: 'advanced_usage',
+        },
+      ],
+    },
+    'config',
+    {
+      type: 'category',
+      label: 'API Reference',
+      items: [
+        {
+          type: 'doc',
+          id: 'cli',
+        },
+        {
+          type: 'doc',
+          id: 'env',
+        },
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Examples',
+      items: [
+        {
+          type: 'doc',
+          id: 'examples',
+        },
+        {
+          type: 'doc',
+          id: 'example_js',
+        },
+      ],
+    },
+    'best_practices',
+    'changelog',
+    'ide_support',
+
+    {
+      type: 'category',
+      label: 'Development',
+      items: [
+        {
+          type: 'doc',
+          id: 'architecture',
+        },
+        {
+          type: 'doc',
+          id: 'development',
+        },
+        {
+          type: 'doc',
+          id: 'contribute',
+        },
+      ],
+    },
+  ],
 };

--- a/tests/command_env.bats
+++ b/tests/command_env.bats
@@ -14,3 +14,10 @@ setup() {
     assert_line --index 2 "BAR=Bar"
     assert_line --index 3 "FOO=bb1da47569d9fbe3b5f2216fdbd4c9b040ccb5c1"
 }
+
+@test "command_env: should merge env with aliased map" {
+    run lets -c lets.aliased-env.yaml env
+    assert_success
+    assert_line --index 0 "ONE=1"
+    assert_line --index 1 "FOO=BAR"
+}

--- a/tests/command_env/lets.aliased-env.yaml
+++ b/tests/command_env/lets.aliased-env.yaml
@@ -1,0 +1,16 @@
+shell: bash
+
+x-default-env: &default-env
+  FOO:
+    sh: echo "BAR"
+
+commands:
+  env:
+    env:
+      ONE: "1"
+      FOO:
+        sh: echo "hello"
+      <<: *default-env
+    cmd: |
+      echo ONE=${ONE}
+      echo FOO=${FOO}

--- a/tests/commands_required/lets.yaml
+++ b/tests/commands_required/lets.yaml
@@ -1,2 +1,1 @@
 shell: bash
-commands_typo:

--- a/tests/global_env.bats
+++ b/tests/global_env.bats
@@ -17,3 +17,10 @@ setup() {
     assert_line --index 5 "BAR=Bar"
     assert_line --index 6 "FOO=bb1da47569d9fbe3b5f2216fdbd4c9b040ccb5c1"
 }
+
+@test "global_env: should merge env with aliased map" {
+    run lets -c lets.aliased-env.yaml env
+    assert_success
+    assert_line --index 0 "ONE=1"
+    assert_line --index 1 "FOO=BAR"
+}

--- a/tests/global_env/lets.aliased-env.yaml
+++ b/tests/global_env/lets.aliased-env.yaml
@@ -1,0 +1,14 @@
+shell: bash
+
+x-default-env: &default-env
+  FOO: BAR
+env:
+  ONE: "1"
+  FOO: BAZ
+  <<: *default-env
+
+commands:
+  env:
+    cmd: |
+      echo ONE=${ONE}
+      echo FOO=${FOO}


### PR DESCRIPTION
* "x-" prefixed top level keywords are now supported. This allows alias this data in env
* env can now alias "x-" prefixed maps which will be merged with "env"
* improve docs - sidebar now has better nesting
* improve docs - add conditional "init" explanation
* add bats and unit tests

## Summary by Sourcery

Add support for top-level custom keywords starting with "x-" and improve YAML aliasing for environment variables

New Features:
- Support for top-level custom keywords prefixed with 'x-'
- Add YAML alias support for environment variables

Enhancements:
- Improve documentation structure and content
- Add validation for top-level keywords in config

Documentation:
- Update sidebar structure
- Add detailed explanation of conditional init
- Update changelog with new features

Tests:
- Add bats and unit tests for new features
- Add tests for env aliasing and keyword validation