### PR TITLE
Resolve GitHub issue 187

### DIFF
--- a/main.go
+++ b/main.go
@@ -127,6 +127,14 @@ func main() {
 			exitCode = execErr.ExitCode()
 		}
 
+		// Check if it's a DependencyError (need to import executor package types)
+		type ExitCoder interface {
+			ExitCode() int
+		}
+		if exitCoder, ok := err.(ExitCoder); ok {
+			exitCode = exitCoder.ExitCode()
+		}
+
 		os.Exit(exitCode)
 	}
 }

--- a/tests/command_depends.bats
+++ b/tests/command_depends.bats
@@ -49,3 +49,30 @@ setup() {
     assert_failure
     assert_line --index 0 "lets: config error: command 'parallel-in-depends' depends on command 'parallel', but parallel cmd is not allowed in depends yet"
 }
+
+@test "command_depends: should show dependency tree on failure" {
+    run lets run-with-failing-dep
+    assert_failure 1
+    assert_output --partial "'fail-command' failed: exit status 1"
+    assert_output --partial "'run-with-failing-dep' ->"
+    assert_output --partial "'fail-command' ⚠️"
+}
+
+@test "command_depends: should show dependency tree with multiple levels" {
+    run lets level2-dep
+    assert_failure 1
+    assert_output --partial "'fail-command' failed: exit status 1"
+    assert_output --partial "'level2-dep' ->"
+    assert_output --partial "'run-with-failing-dep'"
+    assert_output --partial "'fail-command' ⚠️"
+}
+
+@test "command_depends: should run successful deps before showing failure tree" {
+    run lets multiple-deps-one-fail
+    assert_failure 1
+    assert_output --partial "Hello World with level INFO"
+    assert_output --partial "Bar"
+    assert_output --partial "'fail-command' failed: exit status 1"
+    assert_output --partial "'multiple-deps-one-fail' ->"
+    assert_output --partial "'fail-command' ⚠️"
+}

--- a/tests/command_depends/lets.yaml
+++ b/tests/command_depends/lets.yaml
@@ -52,3 +52,30 @@ commands:
       - name: greet-foo
         args: Bar
     cmd: echo I have ref in depends
+
+  # Test commands for dependency failure tree
+  fail-command:
+    description: Command that always fails
+    cmd: exit 1
+
+  run-with-failing-dep:
+    description: Command that depends on a failing command
+    depends:
+      - fail-command
+    cmd: echo "This should not run"
+
+  # More complex dependency chain test
+  level2-dep:
+    description: Command that depends on a failing command through multiple levels
+    depends:
+      - run-with-failing-dep
+    cmd: echo "This should also not run"
+
+  # Test multiple dependencies with one failing
+  multiple-deps-one-fail:
+    description: Command with multiple dependencies where one fails
+    depends:
+      - greet
+      - bar 
+      - fail-command
+    cmd: echo "This should not run"

--- a/tests/command_depends/test_dependency_tree.yaml
+++ b/tests/command_depends/test_dependency_tree.yaml
@@ -1,0 +1,36 @@
+shell: bash
+
+commands:
+  # Basic failing command
+  build-app:
+    description: Simulates a failing build
+    cmd: |
+      echo "Building app..."
+      sleep 1
+      echo "Build failed!"
+      exit 130
+
+  # Command that depends on the failing build
+  run-app:
+    description: Runs the app (depends on build)
+    depends: [build-app]
+    cmd: |
+      echo "Starting application..."
+      echo "App is running!"
+
+  # More complex example with multiple levels
+  deploy-app:
+    description: Deploys the app (depends on run-app, which depends on build-app)
+    depends: [run-app]
+    cmd: |
+      echo "Deploying to production..."
+      echo "Deployment complete!"
+
+  # Example with multiple dependencies where one fails
+  integration-test:
+    description: Runs integration tests
+    depends:
+      - build-app
+    cmd: |
+      echo "Running integration tests..."
+      echo "All tests passed!"


### PR DESCRIPTION
Display a dependency tree in error messages when a command fails within a dependency chain (fixes #187).

This improves debuggability by clearly showing which specific command in the chain failed, rather than just a generic "failed to run command" message for the dependent command.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-dee5c8a2-e0d2-4995-93f0-8607e2cf6afe) · [Cursor](https://cursor.com/background-agent?bcId=bc-dee5c8a2-e0d2-4995-93f0-8607e2cf6afe)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)

## Summary by Sourcery

Show dependency chains in error messages when a dependent command fails by introducing a new DependencyError type, tracking command dependency paths, and adjusting execution and exit code handling accordingly.

New Features:
- Display a visual dependency tree in error output when a command fails within a dependency chain.

Enhancements:
- Extend execution context to carry dependency paths and wrap child failures in DependencyError.
- Update main exit logic to respect DependencyError exit codes alongside existing errors.

Tests:
- Add BATS tests to verify single- and multi-level dependency failure trees.
- Provide YAML-based test scenarios for sophisticated dependency failure chains.