### PR TITLE
slices for max cmd name

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,7 +63,11 @@ func PrintHelpMessage(cmd *cobra.Command) error {
 }
 
 func maxCommandNameLen(cmd *cobra.Command) int {
-	maxCmd := slices.MaxFunc(cmd.Commands(), func(a, b *cobra.Command) int {
+	commands := cmd.Commands()
+	if len(commands) == 0 {
+		return 0
+	}
+	maxCmd := slices.MaxFunc(commands, func(a, b *cobra.Command) int {
 		return cmp.Compare(len(a.Name()), len(b.Name()))
 	})
 	return len(maxCmd.Name())

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -5,6 +5,8 @@ title: Changelog
 
 ## [Unreleased](https://github.com/lets-cli/lets/releases/tag/v0.0.X)
 
+* `[Fixed]` Fixed indentation issues for long commands in help output. Command names are now properly padded for consistent alignment.
+
 ## [0.0.58](https://github.com/lets-cli/lets/releases/tag/v0.0.58)
 
 * `[Added]` `group` directive for commands. Organize commands into groups for better readability in help output. See [config reference for group](/docs/config#group).


### PR DESCRIPTION
- **Use slices to find max command name len**
- **Add changelog entry for slices for max cmd name**

## Summary by Sourcery

Refine command help formatting by correctly calculating the longest command name and document the fix in the changelog.

Bug Fixes:
- Correct maxCommandNameLen to return the length of the longest command name when using slices.MaxFunc.

Documentation:
- Add changelog entry describing the fix to maxCommandNameLen and its use of slices.MaxFunc.