### PR TITLE
Fix crash on malformed local mixin YAML

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -23,6 +23,7 @@ title: Changelog
 * `[Fixed]` Resolve `go to definition` from command references such as `ref: build` to the referenced command in `lets self lsp`.
 * `[Added]` Load local mixin files into LSP storage and command index so mixin commands are available for navigation.
 * `[Changed]` Replace the top-level `--upgrade` flag with the `lets self upgrade` command.
+* `[Fixed]` Return a normal parse error when a local mixin contains malformed YAML instead of crashing.
 
 ## [0.0.59](https://github.com/lets-cli/lets/releases/tag/v0.0.59)
 

--- a/internal/config/config/config.go
+++ b/internal/config/config/config.go
@@ -292,7 +292,7 @@ func (c *Config) readMixins(mixins []*Mixin) error {
 
 	for _, mixin := range mixins {
 		if err := c.readMixin(mixin); err != nil {
-			return fmt.Errorf("failed to read remote mixin config '%s': %w", mixin.Remote.URL, err)
+			return fmt.Errorf("failed to read mixin config '%s': %w", mixin.Source(), err)
 		}
 	}
 

--- a/internal/config/config/mixin.go
+++ b/internal/config/config/mixin.go
@@ -190,3 +190,11 @@ func (m *Mixin) UnmarshalYAML(unmarshal func(any) error) error {
 func (m *Mixin) IsRemote() bool {
 	return m.Remote != nil
 }
+
+func (m *Mixin) Source() string {
+	if m.IsRemote() {
+		return m.Remote.URL
+	}
+
+	return m.FileName
+}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -9,6 +12,33 @@ func TestLoadConfig(t *testing.T) {
 		_, err := Load("", "", "0.0.0-test")
 		if err != nil {
 			t.Errorf("can not load test config: %s", err)
+		}
+	})
+
+	t.Run("returns error for malformed local mixin", func(t *testing.T) {
+		tempDir := t.TempDir()
+
+		mainConfig := "shell: bash\nmixins: [mixin.yaml]\ncommands:\n  ok:\n    cmd: echo ok\n"
+		if err := os.WriteFile(filepath.Join(tempDir, "lets.yaml"), []byte(mainConfig), 0o644); err != nil {
+			t.Fatalf("write main config: %v", err)
+		}
+
+		mixinConfig := "commands:\n  test1:\n    xxx\n    cmd: echo Test\n"
+		if err := os.WriteFile(filepath.Join(tempDir, "mixin.yaml"), []byte(mixinConfig), 0o644); err != nil {
+			t.Fatalf("write mixin config: %v", err)
+		}
+
+		_, err := Load("", tempDir, "0.0.0-test")
+		if err == nil {
+			t.Fatal("expected malformed mixin error")
+		}
+
+		if !strings.Contains(err.Error(), "failed to read mixin config 'mixin.yaml'") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !strings.Contains(err.Error(), "can not parse mixin config mixin.yaml") {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- avoid dereferencing `Remote` when reporting mixin load errors for local mixins
- add `Mixin.Source()` so error messages use the correct local file name or remote URL
- add a regression test for malformed local mixin YAML and document the fix in the changelog

## Testing
- `lets fmt`
- `go test ./internal/config/...`
- `go test ./...`

## Summary by Sourcery

Handle malformed local mixin YAML without crashing and ensure error reporting uses the correct mixin source identifier.

Bug Fixes:
- Prevent crashes when loading malformed local mixin YAML by returning a normal parse error instead.
- Report mixin load errors using a unified mixin source field so local mixins show their file name instead of assuming a remote URL.

Enhancements:
- Add a Mixin source helper to abstract whether a mixin originates from a local file or remote URL.

Documentation:
- Document the fix for malformed local mixin YAML handling in the changelog.

Tests:
- Add a regression test verifying that malformed local mixin YAML produces the expected error messages instead of crashing.