### PR TITLE
Skip prereleases for Homebrew tap and AUR, add lets-beta formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,7 +60,7 @@ brews:
     skip_upload: auto
     conflicts:
       - lets-beta
-    repository:
+    repository: &homebrew-tap
       owner: lets-cli
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
@@ -71,13 +71,12 @@ brews:
     description: "CLI task runner for productive developers - a better alternative to make (prerelease channel)"
     homepage: "https://lets-cli.org/"
     license: "MIT"
+    # skip_upload is a string in goreleaser (compared against "true"/"auto"
+    # after template rendering), so the quoted template is intentional
     skip_upload: '{{ if .Prerelease }}false{{ else }}true{{ end }}'
     conflicts:
       - lets
-    repository:
-      owner: lets-cli
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    repository: *homebrew-tap
     directory: Formula
 
 aurs:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,6 +56,24 @@ brews:
     description: "CLI task runner for productive developers - a better alternative to make"
     homepage: "https://lets-cli.org/"
     license: "MIT"
+    # do not publish prereleases (e.g. v1.0.0-rc1) to the main formula
+    skip_upload: auto
+    conflicts:
+      - lets-beta
+    repository:
+      owner: lets-cli
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+  # prerelease channel: published ONLY for prerelease tags,
+  # installable via `brew install lets-cli/tap/lets-beta`
+  - name: lets-beta
+    description: "CLI task runner for productive developers - a better alternative to make (prerelease channel)"
+    homepage: "https://lets-cli.org/"
+    license: "MIT"
+    skip_upload: '{{ if .Prerelease }}false{{ else }}true{{ end }}'
+    conflicts:
+      - lets
     repository:
       owner: lets-cli
       name: homebrew-tap
@@ -67,6 +85,8 @@ aurs:
     homepage: "https://lets-cli.org/"
     description: "CLI task runner for productive developers - a better alternative to make"
     license: "MIT"
+    # do not publish prereleases to AUR
+    skip_upload: auto
     maintainers:
       - 'Kindritskiy Maksym <kindritskiy.m@gmail.com>'
     contributors:

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -5,6 +5,7 @@ title: Changelog
 
 ## [Unreleased](https://github.com/lets-cli/lets/releases/tag/v0.0.X)
 
+* `[Changed]` Prerelease tags (e.g. `v0.0.62-rc1`) are no longer published to the Homebrew tap `lets` formula or AUR; they are published to a new opt-in `lets-beta` formula instead (`brew install lets-cli/tap/lets-beta`).
 * `[Fixed]` `source <(lets completion -s zsh)` no longer hangs: skip terminal background-color detection when lets runs outside the terminal's foreground process group (e.g. inside process substitution), where the query would suspend the process with SIGTTIN/SIGTTOU.
 * `[Fixed]` Add spacing between the `EXAMPLES` help title and its examples.
 * `[Fixed]` Align styled error output to the left while preserving the padded error badge.

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -11,20 +11,21 @@ brew tap lets-cli/tap
 brew install lets-cli/tap/lets
 ```
 
-## Arch
+### Prereleases
 
-Install the latest binary release from [AUR lets-bin](https://aur.archlinux.org/packages/lets-bin/).
-
-If you use `yay` as your AUR helper:
+The main `lets` formula only receives stable releases. Prerelease versions (e.g. `v0.0.62-rc1`) are published
+to a separate `lets-beta` formula:
 
 ```bash
-yay -S lets-bin
+brew install lets-cli/tap/lets-beta
 ```
 
-You can also install the bleeding edge version from [AUR lets-git](https://aur.archlinux.org/packages/lets-git/).
+Both formulas install the `lets` binary, so they conflict with each other — uninstall one before installing the
+other. To switch back to stable:
 
 ```bash
-yay -S lets-git
+brew uninstall lets-cli/tap/lets-beta
+brew install lets-cli/tap/lets
 ```
 
 ## Shell Script
@@ -68,6 +69,22 @@ To install into a custom lets home directory, set `LETS_HOME`. The binary will b
 
 ```bash
 curl -fsSL https://lets-cli.org/install.sh | LETS_HOME=$HOME/tools/lets bash
+```
+
+## Arch
+
+Install the latest binary release from [AUR lets-bin](https://aur.archlinux.org/packages/lets-bin/).
+
+If you use `yay` as your AUR helper:
+
+```bash
+yay -S lets-bin
+```
+
+You can also install the bleeding edge version from [AUR lets-git](https://aur.archlinux.org/packages/lets-git/).
+
+```bash
+yay -S lets-git
 ```
 
 ## Binary (Manual)
@@ -128,20 +145,6 @@ If your `lets` version is below `0.0.30`, use the shell script and specify the l
 brew upgrade lets-cli/tap/lets
 ```
 
-### Arch
-
-AUR packages provide the latest version.
-
-```bash
-yay -Syu lets-bin
-```
-
-For the bleeding edge package:
-
-```bash
-yay -Syu lets-git
-```
-
 ### Shell Script
 
 Run the install script again to update `lets` to the latest version.
@@ -154,6 +157,20 @@ To update to a specific version:
 
 ```bash
 curl -fsSL https://lets-cli.org/install.sh | LETS_VERSION=v0.0.21 bash
+```
+
+### Arch
+
+AUR packages provide the latest version.
+
+```bash
+yay -Syu lets-bin
+```
+
+For the bleeding edge package:
+
+```bash
+yay -Syu lets-git
 ```
 
 ### Binary


### PR DESCRIPTION
## Problem

Prerelease tags (`v0.0.62-rc1`, `v0.0.62-rc2`) were published to [lets-cli/homebrew-tap](https://github.com/lets-cli/homebrew-tap)'s main `lets` formula (and AUR), so every `brew upgrade` shipped a release candidate to all users.

## Changes

- `brews[lets]` and `aurs[lets-bin]` get `skip_upload: auto` — goreleaser skips publishing when the tag has a prerelease indicator. Prerelease tags still create GitHub (pre)releases with binaries.
- New `brews[lets-beta]` entry with an inverted, templated `skip_upload` (`{{ if .Prerelease }}false{{ else }}true{{ end }}`) — prerelease tags publish an opt-in `Formula/lets-beta.rb`: `brew install lets-cli/tap/lets-beta`. The two formulas declare `conflicts` with each other since both install the `lets` binary.
- Changelog entry.

`goreleaser check` passes (config valid; the `brews` deprecation warning is pre-existing — migrating to `homebrew_casks` would force existing tap users to reinstall, left out of scope).

## Remediation done separately

The tap's `Formula/lets.rb` was already reverted to v0.0.61 (lets-cli/homebrew-tap@7f36657), so brew users are back on stable now.

## Verification notes

- `.Prerelease` renders to e.g. `rc1` for prerelease tags and empty for stable, per goreleaser template docs, so the `lets-beta` condition publishes only on prereleases.
- The real end-to-end check is the next rc tag: expect `lets.rb` untouched, `lets-beta.rb` created, no AUR push.

## Summary by Sourcery

Prevent prerelease versions from being pushed to stable Homebrew and AUR channels and introduce an opt-in Homebrew beta formula.

New Features:
- Add a lets-beta Homebrew formula that is only published for prerelease tags and installable via lets-cli/tap.

Enhancements:
- Configure the main Homebrew lets formula to skip uploads for prerelease tags and declare conflicts with the beta formula.
- Configure the AUR lets-bin package to skip uploads for prerelease tags.

Documentation:
- Update the changelog to document the new prerelease handling and lets-beta formula.