### PR TITLE
Fix self-upgrade interrupt handling

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -8,6 +8,7 @@ title: Changelog
 * `[Added]` Add `checksum.files`, `checksum.sh`, and `checksum.persist` command checksum syntax while keeping the old checksum format compatible.
 * `[Added]` Add `lets self upgrade --pre` to opt into upgrading to the latest prerelease.
 * `[Added]` Add `lets self fix` config migration command with `--dry-run` preview output for deprecated checksum syntax.
+* `[Fixed]` Allow `lets self upgrade` downloads to respond to Ctrl-C.
 * `[Fixed]` Make checksum calculation respect command-level `work_dir` overrides.
 * `[Fixed]` Restore the release checkout after the GoReleaser dry run so prerelease publishing does not fail on a dirty `go.mod`.
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -159,12 +159,24 @@ func getContext() context.Context {
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	return signalContext(context.Background(), ch, func() {
+		signal.Stop(ch)
+	})
+}
+
+func signalContext(parent context.Context, ch <-chan os.Signal, stop func()) context.Context {
+	ctx, cancel := context.WithCancel(parent)
 
 	go func() {
-		sig := <-ch
-		log.Printf("signal received: %s", sig)
-		cancel()
+		defer stop()
+
+		select {
+		case sig := <-ch:
+			log.Printf("signal received: %s", sig)
+			cancel()
+		case <-parent.Done():
+			cancel()
+		}
 	}()
 
 	return ctx

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"context"
+	"os"
 	"testing"
+	"time"
 
 	cmdpkg "github.com/lets-cli/lets/internal/cmd"
 	"github.com/lets-cli/lets/internal/settings"
@@ -66,6 +69,43 @@ func TestFailOnConfigError(t *testing.T) {
 	if failOnConfigError(root, current, &flags{version: true}) {
 		t.Fatal("expected --version to allow missing config")
 	}
+}
+
+func TestSignalContext(t *testing.T) {
+	t.Run("cancels and stops signal notification after first signal", func(t *testing.T) {
+		signals := make(chan os.Signal, 1)
+		stopped := make(chan struct{})
+		ctx := signalContext(context.Background(), signals, func() {
+			close(stopped)
+		})
+
+		signals <- os.Interrupt
+
+		select {
+		case <-ctx.Done():
+		case <-time.After(time.Second):
+			t.Fatal("expected signal context to be canceled")
+		}
+
+		select {
+		case <-stopped:
+		case <-time.After(time.Second):
+			t.Fatal("expected signal notification to stop")
+		}
+	})
+
+	t.Run("cancels when parent context is canceled", func(t *testing.T) {
+		parent, cancel := context.WithCancel(context.Background())
+		ctx := signalContext(parent, make(chan os.Signal), func() {})
+
+		cancel()
+
+		select {
+		case <-ctx.Done():
+		case <-time.After(time.Second):
+			t.Fatal("expected signal context to be canceled by parent")
+		}
+	})
 }
 
 func TestShouldCheckForUpdate(t *testing.T) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -72,6 +72,16 @@ func TestFailOnConfigError(t *testing.T) {
 }
 
 func TestSignalContext(t *testing.T) {
+	assertClosed := func(t *testing.T, ch <-chan struct{}, message string) {
+		t.Helper()
+
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			t.Fatal(message)
+		}
+	}
+
 	t.Run("cancels and stops signal notification after first signal", func(t *testing.T) {
 		signals := make(chan os.Signal, 1)
 		stopped := make(chan struct{})
@@ -81,30 +91,34 @@ func TestSignalContext(t *testing.T) {
 
 		signals <- os.Interrupt
 
-		select {
-		case <-ctx.Done():
-		case <-time.After(time.Second):
-			t.Fatal("expected signal context to be canceled")
-		}
-
-		select {
-		case <-stopped:
-		case <-time.After(time.Second):
-			t.Fatal("expected signal notification to stop")
-		}
+		assertClosed(t, ctx.Done(), "expected signal context to be canceled")
+		assertClosed(t, stopped, "expected signal notification to stop")
 	})
 
 	t.Run("cancels when parent context is canceled", func(t *testing.T) {
 		parent, cancel := context.WithCancel(context.Background())
-		ctx := signalContext(parent, make(chan os.Signal), func() {})
+		stopped := make(chan struct{})
+		ctx := signalContext(parent, make(chan os.Signal), func() {
+			close(stopped)
+		})
 
 		cancel()
 
-		select {
-		case <-ctx.Done():
-		case <-time.After(time.Second):
-			t.Fatal("expected signal context to be canceled by parent")
-		}
+		assertClosed(t, ctx.Done(), "expected signal context to be canceled by parent")
+		assertClosed(t, stopped, "expected signal notification to stop")
+	})
+
+	t.Run("cancels when parent context is already canceled", func(t *testing.T) {
+		parent, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		stopped := make(chan struct{})
+		ctx := signalContext(parent, make(chan os.Signal), func() {
+			close(stopped)
+		})
+
+		assertClosed(t, ctx.Done(), "expected signal context to be canceled by parent")
+		assertClosed(t, stopped, "expected signal notification to stop")
 	})
 }
 


### PR DESCRIPTION
## Summary

Fix `lets self upgrade` interrupt handling so an in-progress download responds to Ctrl-C by canceling the shared CLI context and then restoring normal signal behavior for any later interrupt.

## Root Cause

The CLI signal handler kept SIGINT/SIGTERM registered after the first signal. If the self-upgrade path was still blocked while cancellation propagated, later Ctrl-C presses were still intercepted instead of falling back to the process default behavior.

## Changes

- Extract signal-to-context wiring into a small helper.
- Stop signal notification after the first handled signal or parent context cancellation.
- Add regression coverage for signal cancellation and signal notification cleanup.
- Add an Unreleased changelog entry.

## Validation

- `go test ./internal/cli -run TestSignalContext -count=1`
- `go test ./...`

## Summary by Sourcery

Improve CLI signal handling to ensure self-upgrade downloads respond correctly to interrupts and restore default behavior after the first signal.

Bug Fixes:
- Ensure `lets self upgrade` downloads are canceled on the first Ctrl-C and stop custom signal handling afterward.

Enhancements:
- Extract reusable helper to wire OS signals into cancellable contexts for CLI operations.

Documentation:
- Document the fix for `lets self upgrade` interrupt handling in the Unreleased changelog.

Tests:
- Add regression tests covering signal-driven context cancellation and cleanup of signal notifications.