### PR TITLE
Add self update alias

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -5,6 +5,7 @@ title: Changelog
 
 ## [Unreleased](https://github.com/lets-cli/lets/releases/tag/v0.0.X)
 
+* `[Added]` Add `update` as an alias for `lets self upgrade`.
 * `[Added]` Add `checksum.files`, `checksum.sh`, and `checksum.persist` command checksum syntax while keeping the old checksum format compatible.
 * `[Added]` Add `lets self upgrade --pre` to opt into upgrading to the latest prerelease.
 * `[Added]` Add `lets self fix` config migration command with `--dry-run` preview output for deprecated checksum syntax.

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -418,37 +418,39 @@ func TestSelfCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("should run self upgrade subcommand", func(t *testing.T) {
-		bufOut := new(bytes.Buffer)
-		called := false
+	for _, command := range []string{"upgrade", "update"} {
+		t.Run("should run self "+command+" subcommand", func(t *testing.T) {
+			bufOut := new(bytes.Buffer)
+			called := false
 
-		rootCmd := CreateRootCommand("v0.0.0-test", "")
-		rootCmd.SetArgs([]string{"self", "upgrade"})
-		rootCmd.SetOut(bufOut)
-		rootCmd.SetErr(bufOut)
-		selfCmd := &cobra.Command{
-			Use:   "self",
-			Short: "Manage lets CLI itself",
-		}
-		rootCmd.AddCommand(selfCmd)
+			rootCmd := CreateRootCommand("v0.0.0-test", "")
+			rootCmd.SetArgs([]string{"self", command})
+			rootCmd.SetOut(bufOut)
+			rootCmd.SetErr(bufOut)
+			selfCmd := &cobra.Command{
+				Use:   "self",
+				Short: "Manage lets CLI itself",
+			}
+			rootCmd.AddCommand(selfCmd)
 
-		selfCmd.AddCommand(initUpgradeCommandWith(func(_ *cobra.Command) (upgrade.Upgrader, error) {
-			return mockUpgraderFunc(func(ctx context.Context) error {
-				called = true
+			selfCmd.AddCommand(initUpgradeCommandWith(func(_ *cobra.Command) (upgrade.Upgrader, error) {
+				return mockUpgraderFunc(func(ctx context.Context) error {
+					called = true
 
-				return nil
-			}), nil
-		}))
+					return nil
+				}), nil
+			}))
 
-		err := rootCmd.Execute()
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+			err := rootCmd.Execute()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-		if !called {
-			t.Fatal("expected upgrader to be called")
-		}
-	})
+			if !called {
+				t.Fatal("expected upgrader to be called")
+			}
+		})
+	}
 
 	t.Run("should pass pre flag to self upgrade factory", func(t *testing.T) {
 		bufOut := new(bytes.Buffer)

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -49,9 +49,10 @@ func upgradeProgress(stderr io.Writer, appSettings settings.Settings) fetch.Prog
 
 func initUpgradeCommandWith(createUpgrader upgraderFactory) *cobra.Command {
 	upgradeCmd := &cobra.Command{
-		Use:   "upgrade",
-		Short: "Upgrade lets to latest version",
-		Args:  cobra.NoArgs,
+		Use:     "upgrade",
+		Aliases: []string{"update"},
+		Short:   "Upgrade lets to latest version",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			upgrader, err := createUpgrader(cmd)
 			if err != nil {


### PR DESCRIPTION
## Summary

- add `update` as an alias for `lets self upgrade`
- verify both command names invoke the same upgrader path
- document the new alias in the changelog

## Why

`lets self update` is a familiar spelling for updating a CLI. Making it a native alias preserves the existing `upgrade` implementation, flags, and error behavior without duplicating command logic.

## User impact

Users can now run either `lets self upgrade` or `lets self update`. The `--pre` flag remains available through the alias.

## Validation

- `lets test` — 307 Go tests, 150 Bats tests, and 4 completion tests passed
- `lets lint` — 0 issues
- `go run ./cmd/lets self update --help` — alias resolves to the upgrade command and exposes `--pre`

## Summary by Sourcery

Add a new `update` alias for the `lets self upgrade` command and ensure both names share the same upgrade behavior.

New Features:
- Introduce `update` as an alias for the `self upgrade` CLI subcommand.

Documentation:
- Document the new `update` alias for `lets self upgrade` in the changelog.

Tests:
- Extend self command tests to verify both `upgrade` and `update` subcommands invoke the same upgrader path.