### PR TITLE
Release anouncement for 0.0.62

### DIFF
--- a/docs/blog/2026-08-02-lets-0.0.63.md
+++ b/docs/blog/2026-08-02-lets-0.0.63.md
@@ -1,0 +1,432 @@
+---
+slug: lets-0-0-63
+title: "Lets 0.0.63"
+description: "Structured checksums, safer upgrades, remote configs, dotenv files, clearer failures, command groups, user themes, and an Agent Skill—everything new since 0.0.55."
+author: Kindritskiy Max
+author_title: Lets core developer
+author_url: https://github.com/kindermax
+author_image_url: https://github.com/kindermax.png
+tags: [lets, release]
+---
+
+Lets 0.0.63 is available now.
+
+Important for existing installations: the installer-managed binary now lives at `$HOME/.lets/bin/lets`, with a symlink from a directory in your `PATH`. Follow the [Upgrade](#upgrade) section once to move an older installation safely.
+
+If you are coming from 0.0.55, this release is much more than a collection of fixes.
+
+Lets can now run a config from a URL, load dotenv files, migrate checksum configuration, explain failed dependencies, and teach AI agents to use project tasks.
+
+The result is a task runner that is easier to share, easier to understand when something goes wrong, and more pleasant to use every day.
+
+<!--truncate-->
+
+## Highlights
+
+- [Migrate an existing installation into the new user-owned layout](#upgrade).
+- [Configure checksums with one clear, migratable structure](#checksums-are-clearer-and-easier-to-migrate).
+- [Run and refresh shared task workflows from a URL](#run-config-from-a-url).
+- [See the complete dependency path when a command fails](#failures-now-show-the-route-to-the-problem).
+- [Install a bundled Agent Skill for compatible coding agents](#help-ai-coding-agents-use-the-tasks-you-already-have).
+
+## Safer installation and upgrades
+
+The new filesystem layout separates the managed binary from the command exposed through `PATH`.
+
+By default, the installer writes the binary to `$HOME/.lets/bin/lets`. It creates a symlink in the first preferred directory already present in `PATH`:
+
+- `$HOME/.local/bin`
+- `$HOME/bin`
+- `$HOME/.bin`
+
+If none is available, the installer creates `$HOME/.local/bin`, places the symlink there, and asks to add that directory to your shell profile.
+
+If you want to install lets on CI or in Dockerfile, use `LETS_INSTALL_NO_PROMPT=1` to suppress profile updating prompts.
+
+`lets self upgrade` follows the symlink and replaces the managed target. It refuses common system-managed locations and redirects Homebrew users to the correct package-manager command.
+
+Prereleases remain opt-in in 0.0.63. Release candidates do not replace the stable Homebrew formula or AUR package. Testers using an installer-managed copy can opt in with:
+
+```bash
+lets self upgrade --pre
+```
+
+Homebrew users can install the separate formula:
+
+```bash
+brew install lets-cli/tap/lets-beta
+```
+
+The stable and beta formulas both provide the `lets` binary, so uninstall one before switching to the other.
+
+## Upgrade
+
+Already have Lets installed? First check the version and the binary currently selected by your `PATH`:
+
+```bash
+lets --version
+command -v lets
+```
+
+Then use the upgrade path that matches the original installation method.
+
+### Homebrew
+
+Keep the installation managed by Homebrew:
+
+```bash
+brew upgrade lets-cli/tap/lets
+```
+
+Do not use `lets self upgrade` for a Homebrew installation.
+
+### Arch Linux
+
+Keep the installation managed by AUR:
+
+```bash
+yay -Syu lets-bin
+```
+
+### Installer or manually downloaded binary
+
+If you are upgrading from 0.0.55, use the current installer to migrate to the new user-owned layout:
+
+```bash
+curl -fsSL https://lets-cli.org/install.sh | bash
+```
+
+The old `lets --upgrade` command replaces the binary at its current path. It does not move an existing 0.0.55 installation into the new layout.
+
+The installer refuses to overwrite a non-Homebrew binary at `/usr/local/bin/lets`. If it reports that legacy installation, confirm it was not installed by Homebrew, then run:
+
+```bash
+sudo rm /usr/local/bin/lets
+curl -fsSL https://lets-cli.org/install.sh | bash
+```
+
+If `/usr/local/bin/lets` is managed by Homebrew, leave it in place and use `brew upgrade lets-cli/tap/lets` instead.
+
+### Verify the active binary
+
+Open a new shell after the installer updates your shell profile, then verify the command, symlink, and version:
+
+```bash
+command -v lets
+ls -l "$(command -v lets)"
+lets --version
+```
+
+With the default installer settings, the symlink should resolve to `$HOME/.lets/bin/lets`, and the version should be 0.0.63.
+
+If `command -v lets` still shows an older custom path, that copy appears earlier in `PATH`. Remove it or move the new symlink directory earlier, but only after confirming the new binary works.
+
+After this one-time migration, future installer-managed updates are:
+
+```bash
+lets self upgrade
+lets self update
+```
+
+`lets self update` is a new alias for the same operation.
+
+See the [installation guide](/docs/installation) for binaries, source builds, CI, and uninstall instructions.
+
+## Run config from a URL
+
+Lets can now use an HTTP or HTTPS URL as its main config:
+
+```bash
+lets -c https://example.com/lets.yaml build
+```
+
+The config is downloaded and cached in `~/.config/lets/remote-configs/`. Future runs use the cached copy, while `--no-cache` forces a refresh:
+
+```bash
+lets --no-cache -c https://example.com/lets.yaml build
+```
+
+Remote configs make it practical to publish a shared workflow once and invoke it from a repository, CI job, or onboarding guide without first copying a file into place.
+
+Commands run from the directory where you invoke Lets unless they declare `work_dir`, so the remote workflow can still operate on the current project.
+
+Downloads for remote configs and remote mixins now show progress in an interactive terminal. Cache hits stay quiet, and `--no-cache` refreshes both kinds of remote file.
+
+Read more in the [remote configs](/docs/config#remote-configs) and [remote mixins](/docs/config#remote-mixins-experimental) documentation.
+
+## Load `.env` files directly
+
+Global and command-level `env_file` support removes a common layer of shell setup. Files may be required, optional, or selected using values resolved earlier in the config:
+
+```yaml
+shell: bash
+
+env:
+  TARGET: dev
+
+env_file:
+  - .env.${TARGET}
+  - -.env.local
+  - name: .env.${LETS_OS}
+    required: true
+
+commands:
+  serve:
+    env:
+      SERVICE: api
+    env_file:
+      - .env.${TARGET}.${SERVICE}
+      - -.env.override
+    cmd: ./bin/serve
+```
+
+The `-` prefix marks a file as optional. Paths are resolved relative to the config directory, not the command's `work_dir`.
+
+The precedence is deliberate: a global `env_file` overrides global `env`, a command `env_file` overrides command `env`, and command-line options such as `-E KEY=value` still win at the end.
+
+See the [environment reference](/docs/env#env_file-precedence) for the complete order.
+
+Lets also exposes `LETS_OS` and `LETS_ARCH`, which makes platform-specific files and commands straightforward:
+
+```yaml
+env_file: .env.${LETS_OS}.${LETS_ARCH}
+```
+
+## Checksums are clearer and easier to migrate
+
+Checksum configuration now has one structured shape. Use `checksum.files` for files or globs, `checksum.sh` for a revision supplied by a command, and `checksum.persist` to remember the value between successful runs.
+
+For example, install dependencies only when the lockfile changes:
+
+```yaml
+commands:
+  build:
+    checksum:
+      files:
+        - package-lock.json
+      persist: true
+    cmd: |
+      if [[ ${LETS_CHECKSUM_CHANGED} == true ]]; then
+        npm ci
+      fi
+      npm run build
+```
+
+On the first run, `LETS_CHECKSUM_CHANGED` is `true`. It becomes `false` until an input changes. Lets saves the new checksum only after the command exits successfully, so a failed setup is retried next time.
+
+Use `checksum.sh` when a file list is not the right source of truth:
+
+```yaml
+checksum:
+  sh: git rev-parse HEAD
+```
+
+`files` and `sh` are mutually exclusive. File checksums now also honor the command-level `work_dir`, so relative paths resolve from the same directory as the command.
+
+The previous direct `checksum` list or map and command-level `persist_checksum` remain compatible, but are deprecated. Preview an automatic migration, then apply it:
+
+```bash
+lets self fix --dry-run
+lets self fix
+```
+
+`self fix` updates the main config and local mixins. Remote mixins are left unchanged with a warning because Lets does not own those files. See the [`checksum` reference](/docs/config#checksum) for named checksums and environment variables.
+
+## Failures now show the route to the problem
+
+A failed dependency used to leave you reconstructing the call chain yourself. Lets now prints the full command tree and points to the failing leaf:
+
+```text
+ERROR
+
+Failed to run command 'lint'.
+Exit status 1.
+
+COMMAND TREE:
+  └─ deploy
+    └─ build
+      └─ lint   <-- failed here
+```
+
+Typos are friendlier too:
+
+```text
+Unknown command "slef" for "lets"
+
+Did you mean this?
+    self
+```
+
+Unknown commands now exit with status 2, which distinguishes incorrect CLI usage from a task that ran and failed.
+
+Help and error output received a broader visual cleanup too: spacing is more consistent, long command names stay aligned, and logging uses one predictable `lets:` prefix.
+
+## Keep large command lists readable
+
+The new `group` directive lets a project turn a long flat help screen into a small menu:
+
+```yaml
+commands:
+  build:
+    group: Development
+    description: Build the application
+    cmd: npm run build
+
+  test:
+    group: Development
+    description: Run the test suite
+    cmd: npm test
+
+  deploy:
+    group: Operations
+    description: Deploy the application
+    cmd: ./deploy.sh
+```
+
+Running `lets help` groups related commands:
+
+```text
+COMMANDS:
+  DEVELOPMENT
+    build       Build the application
+    test        Run the test suite
+  OPERATIONS
+    deploy      Deploy the application
+```
+
+This is purely organizational: command names and invocation stay unchanged. See the [`group` reference](/docs/config#group).
+
+Configs can also use custom top-level keys beginning with `x-`, so YAML anchors can hold reusable data without failing validation. Environment mappings now merge YAML aliases too:
+
+```yaml
+x-default-env: &default-env
+  LOG_LEVEL: info
+  REGION: eu-central-1
+
+env:
+  <<: *default-env
+  LOG_LEVEL: debug
+```
+
+Unknown top-level keys that do not begin with `x-` are rejected, catching misspelled directives early.
+
+## Personal Lets settings
+
+Lets now allows to configure personal preferences:
+
+```text
+~/.config/lets/config.yaml
+```
+
+Find or open that file without remembering the path:
+
+```bash
+lets self config path
+lets self config edit
+```
+
+The settings file controls color, background update notifications, and the help/error theme:
+
+```yaml
+no_color: false
+theme: synthwave
+upgrade_notify: true
+```
+
+Available themes are `default`, `ansi`, and `synthwave`. Environment variables continue to take precedence over the settings file.
+
+Interactive sessions can also notify you about new Lets versions in the background. Set `LETS_CHECK_UPDATE=1` or `upgrade_notify: false` when you prefer a quiet CLI.
+
+The complete list is in the new [settings reference](/docs/settings).
+
+## Quality-of-life improvements
+
+Many smaller changes are aimed at reducing daily friction:
+
+- `lets self doc` opens the online documentation in your browser.
+- `lets self update` is a shorter alias for `lets self upgrade`.
+- `lets self upgrade --pre` opts an installer-managed copy into prereleases.
+- `lets --version` works without a `lets.yaml` in the current directory.
+- Root and `self` help follow the same predictable help path.
+- Help output has better spacing and alignment, including long command names and example blocks.
+- Zsh completion understands root flags before commands and respects `--`.
+- `source <(lets completion -s zsh)` no longer hangs under shell job control.
+- Self-upgrades and remote downloads show progress in interactive terminals while staying quiet in redirected output.
+- Pressing Ctrl-C now stops a self-upgrade while its release or checksum file is downloading.
+
+## Better editor navigation, without a C toolchain
+
+The built-in language server can now follow more of the relationships inside real-world Lets configs:
+
+- `ref: build` navigates to the referenced command.
+- YAML merge aliases such as `<<: *test` navigate to their anchor.
+- Commands defined in local mixins are indexed for navigation.
+- Malformed local mixins report a normal parse error instead of crashing.
+
+At the same time, the YAML parser moved to a pure-Go implementation. Building Lets no longer requires the C toolchain introduced around 0.0.55.
+
+The zsh completion path is more reliable too. Root flags such as `-c` and `--config` work before command names, `--` is respected as the end of root flags, and loading completion with process substitution no longer hangs:
+
+```zsh
+source <(lets completion -s zsh)
+```
+
+## Help AI coding agents use the tasks you already have
+
+Lets now ships an experimental Agent Skill: a portable set of instructions that tells compatible coding agents to inspect `lets.yaml`, discover commands, respect mixins, and prefer the project's task interface.
+
+Inspect the bundled skill:
+
+```bash
+lets self skills show
+```
+
+Install it for the current repository:
+
+```bash
+lets self skills install --local
+```
+
+Or install it for your user:
+
+```bash
+lets self skills install --global
+```
+
+When a newer Lets release includes improved guidance, update known local and global copies with:
+
+```bash
+lets self skills update
+```
+
+See [Agent Skills](/docs/agent_skills) for install paths, custom locations, and update behavior.
+
+## Before you upgrade from 0.0.55
+
+Most changes are additive, but four migrations are worth checking:
+
+1. The deprecated `eval_env` directive has been removed. Replace it with `env` using `sh` mode:
+
+   ```yaml
+   env:
+     GIT_SHA:
+       sh: git rev-parse --short HEAD
+   ```
+
+2. The top-level `--upgrade` flag moved to `lets self upgrade`.
+
+3. Unknown commands now exit with status 2. If a script asserts the old status, update it.
+
+4. Old checksum syntax still works, but is deprecated. Run `lets self fix --dry-run` to preview the new structure, then `lets self fix` to migrate the main config and local mixins.
+
+If you build Lets from source, version 0.0.63 requires Go 1.26.
+
+Version 0.0.56 was not published because of build issues; its configuration improvements shipped in the releases that followed.
+
+## The full list
+
+This post focuses on the changes that affect everyday workflows. For every fix, refactor, and dependency update, read the [changelog](/docs/changelog).
+
+You can also compare [`v0.0.55...v0.0.63`](https://github.com/lets-cli/lets/compare/v0.0.55...v0.0.63).
+
+Thank you to everyone who reported issues, tested release candidates, and contributed changes. If something does not behave as expected, please [open an issue](https://github.com/lets-cli/lets/issues/new).

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -105,7 +105,6 @@
       "version": "4.14.2",
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
       "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "4.14.2",
         "@algolia/requester-common": "4.14.2",
@@ -196,7 +195,6 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.3.tgz",
       "integrity": "sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -2689,7 +2687,6 @@
       "version": "7.12.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
       "integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/generator": "^7.12.5",
@@ -3011,7 +3008,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-6.5.0.tgz",
       "integrity": "sha512-jIbu36GMjfK8HCCQitkfVVeQ2vSXGfq0ef0GO9HUxZGjal6Kvpkk4PwpkFP+OyCzF+skQFT9aWrUqekT3pKF8w==",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.18.5",
         "@svgr/babel-preset": "^6.5.0",
@@ -3302,7 +3298,6 @@
       "version": "18.0.21",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
       "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -3583,7 +3578,6 @@
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
       "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3631,7 +3625,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3691,7 +3684,6 @@
       "version": "4.14.2",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
       "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
-      "peer": true,
       "dependencies": {
         "@algolia/cache-browser-local-storage": "4.14.2",
         "@algolia/cache-common": "4.14.2",
@@ -4130,7 +4122,6 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -4728,7 +4719,6 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4978,7 +4968,6 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -7842,7 +7831,6 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -8507,7 +8495,6 @@
           "url": "https://tidelift.com/funding/github/npm/postcss"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -9299,7 +9286,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -9422,7 +9408,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -9488,7 +9473,6 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
       "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
-      "peer": true,
       "dependencies": {
         "@types/react": "*",
         "prop-types": "^15.6.2"
@@ -9516,7 +9500,6 @@
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -9769,7 +9752,6 @@
       "version": "7.12.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
       "integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/generator": "^7.12.5",
@@ -11842,7 +11824,6 @@
       "version": "5.76.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.1.tgz",
       "integrity": "sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -11941,7 +11922,6 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -12072,7 +12052,6 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -12510,7 +12489,6 @@
       "version": "4.14.2",
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
       "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
-      "peer": true,
       "requires": {
         "@algolia/client-common": "4.14.2",
         "@algolia/requester-common": "4.14.2",
@@ -12592,7 +12570,6 @@
       "version": "7.19.3",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.3.tgz",
       "integrity": "sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==",
-      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -14341,7 +14318,6 @@
           "version": "7.12.9",
           "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
           "integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
-          "peer": true,
           "requires": {
             "@babel/code-frame": "^7.10.4",
             "@babel/generator": "^7.12.5",
@@ -14538,7 +14514,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-6.5.0.tgz",
       "integrity": "sha512-jIbu36GMjfK8HCCQitkfVVeQ2vSXGfq0ef0GO9HUxZGjal6Kvpkk4PwpkFP+OyCzF+skQFT9aWrUqekT3pKF8w==",
-      "peer": true,
       "requires": {
         "@babel/core": "^7.18.5",
         "@svgr/babel-preset": "^6.5.0",
@@ -14782,7 +14757,6 @@
       "version": "18.0.21",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
       "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
-      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -15055,8 +15029,7 @@
     "acorn": {
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
-      "peer": true
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
@@ -15087,7 +15060,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -15131,7 +15103,6 @@
       "version": "4.14.2",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
       "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
-      "peer": true,
       "requires": {
         "@algolia/cache-browser-local-storage": "4.14.2",
         "@algolia/cache-common": "4.14.2",
@@ -15465,7 +15436,6 @@
       "version": "4.21.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
       "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
-      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -15891,7 +15861,6 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -16046,7 +16015,6 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -18120,7 +18088,6 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -18590,7 +18557,6 @@
       "version": "8.4.18",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.18.tgz",
       "integrity": "sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==",
-      "peer": true,
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -19103,7 +19069,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -19195,7 +19160,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -19249,7 +19213,6 @@
       "version": "npm:@docusaurus/react-loadable@5.5.2",
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
       "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
-      "peer": true,
       "requires": {
         "@types/react": "*",
         "prop-types": "^15.6.2"
@@ -19267,7 +19230,6 @@
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -19465,7 +19427,6 @@
           "version": "7.12.9",
           "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz",
           "integrity": "sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==",
-          "peer": true,
           "requires": {
             "@babel/code-frame": "^7.10.4",
             "@babel/generator": "^7.12.5",
@@ -20938,7 +20899,6 @@
       "version": "5.76.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.1.tgz",
       "integrity": "sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==",
-      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -21030,7 +20990,6 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -21122,7 +21081,6 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",

--- a/docs/research/release-announcement-patterns.md
+++ b/docs/research/release-announcement-patterns.md
@@ -1,0 +1,238 @@
+# Release announcement patterns for Lets v0.0.62
+
+Research date: 2026-07-27
+
+## Question
+
+What do clear, comprehensible release announcements from established software projects do well, and which of those patterns should shape a Lets v0.0.62 post covering the cumulative changes since v0.0.55?
+
+## Executive recommendation
+
+Treat the v0.0.62 post as a curated guide to the **user-visible difference between v0.0.55 and v0.0.62**, not as seven changelogs pasted together.
+
+The strongest common pattern is:
+
+1. Open with one sentence saying what shipped and one sentence explaining why the release matters.
+2. Put the upgrade command and a short, linked “At a glance” list near the top.
+3. Organize the body by user outcome or workflow, not by commit, subsystem, or intermediate version.
+4. Give each major change a compact narrative: previous friction → new behavior → runnable example → practical payoff → caveat or documentation link.
+5. Collect small refinements into a scannable quality-of-life section.
+6. Separate compatibility and migration information so readers can assess upgrade risk quickly.
+7. Link to the exhaustive `v0.0.55...v0.0.62` changelog/diff instead of forcing every fix into the article.
+8. Close with thanks and a clear place to report problems or give feedback.
+
+The closest overall model is Astro 5.0’s ordering, strengthened with Bun’s cumulative/workflow framing, Go’s selectivity, TypeScript’s problem/solution examples, Tailwind’s benefit-led summary, and the upgrade/migration discipline used by Rust and Vite.
+
+## First-party examples
+
+### 1. Tailwind CSS v4.0
+
+Official source: [Tailwind CSS v4.0](https://tailwindcss.com/blog/tailwindcss-v4)
+
+What it does:
+
+- Opens with a concise positioning statement, then gives a linked list of concrete highlights before the deep dive.
+- Describes highlights in user-benefit language rather than only naming implementation changes.
+- Makes claims tangible with benchmark numbers, a comparison table, numbered setup steps, and focused code examples.
+- Gives new and existing users different next actions.
+- Ends with a human voice and a request to try the release and provide feedback.
+
+Reuse for Lets:
+
+- Put five or fewer strongest outcomes above the fold.
+- For each major command or configuration change, show a copyable example immediately after the explanation.
+- Quantify speed or reduction in steps only when the repository contains reproducible evidence.
+- Keep a personable voice, but adapt it to Lets.
+
+### 2. Visual Studio Code monthly release notes
+
+Official source: [Visual Studio Code 1.126](https://code.visualstudio.com/updates/v1_126) and the [release notes archive](https://code.visualstudio.com/updates/archive)
+
+What it does:
+
+- Starts with the release date, downloads, a one-sentence theme, and three linked highlights.
+- Describes each feature in terms of the task it improves.
+- Uses screenshots directly beside the behavior they demonstrate.
+- Groups details under recognizable user-facing areas.
+- States rollout and update behavior near the start.
+
+Reuse for Lets:
+
+- Use a short “Highlights” list with anchor links.
+- If a change is easier to see than explain, include a terminal capture or short animation adjacent to that section.
+- Use workflow headings rather than repository package names.
+
+### 3. TypeScript 5.5 release notes
+
+Official source: [TypeScript 5.5 release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html)
+
+What it does:
+
+- Builds major feature explanations around a real limitation in the prior version, then shows the same code working in the new version.
+- Uses comments and visible error/success markers.
+- Explains why the behavior changed after demonstrating it.
+- Separates reliability improvements and optimizations from headline features.
+- Has a dedicated “Notable Behavioral Changes” section.
+
+Reuse for Lets:
+
+- Prefer before/after examples when v0.0.62 removes an old workaround.
+- Annotate command output so the important change is obvious.
+- Keep quality-of-life and reliability work visible.
+- Put behavior changes and deprecations in an explicit upgrade-impact section.
+
+### 4. Go 1.23
+
+Official source: [Go 1.23 is released](https://go.dev/blog/go1.23)
+
+What it does:
+
+- Leads with both the download path and an exact upgrade command.
+- Groups a deliberately short selection of highlights by recognizable category.
+- Gives a minimal example for the most important language change.
+- Sends readers to detailed release notes for completeness.
+- Closes with acknowledgements and a direct issue-reporting link.
+
+Reuse for Lets:
+
+- Put the exact installation and upgrade commands near the top.
+- Say “highlights” when the article is curated.
+- Keep less important items short and link outward for details.
+
+### 5. Rust 1.85.0
+
+Official source: [Announcing Rust 1.85.0 and Rust 2024](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0/)
+
+What it does:
+
+- Opens with a plain announcement and one-line explanation of the principal milestone.
+- Immediately provides the upgrade command, detailed notes, testing channels, and bug-reporting route.
+- Gives the largest change first.
+- Links summary bullets to deeper documentation.
+- Gives migration a distinct subsection.
+
+Reuse for Lets:
+
+- Make the principal theme obvious before listing details.
+- Explain the limits or semantics of new convenience features.
+- Give migration information enough prominence for readers who skim.
+
+### 6. Vite 6
+
+Official source: [Vite 6.0 is out!](https://vite.dev/blog/announcing-vite6)
+
+What it does:
+
+- Places the release in the project’s broader direction.
+- Offers quick links to docs, migration guidance, and the full changelog.
+- Provides a concrete “Getting started” section.
+- Calls out supported runtime versions and dropped versions separately.
+- Labels experimental APIs and their intended audience.
+
+Reuse for Lets:
+
+- Add compact links to installation, documentation, migration, and the full changelog.
+- State changed requirements explicitly.
+- Label experimental features and say who does not need to change anything.
+
+### 7. Astro 5.0
+
+Official source: [Astro 5.0](https://astro.build/blog/astro-5/)
+
+What it does:
+
+- Opens with a benefit-led proposition and a linked highlights list.
+- Puts new-project and upgrade commands before long feature explanations.
+- Builds feature sections around problem, solution, example, payoff, caveat, and documentation.
+- Labels experimental features separately.
+- Directs smaller fixes to full release notes.
+
+Reuse for Lets:
+
+- Use this base ordering: proposition → highlights → upgrade → major workflows → experimental/smaller items → full notes → thanks.
+- Put the upgrade command before the deep dive.
+- When a large internal change needs no user action, say so explicitly.
+
+### 8. Bun 1.1
+
+Official source: [Bun 1.1](https://bun.sh/blog/bun-v1.1)
+
+What it does:
+
+- Establishes the cumulative scope since the previous milestone.
+- Organizes a large body of changes by recognizable product surface.
+- Uses small runnable demonstrations, old/new code, visible output, and quantified results.
+- Gives behavior changes, notable fixes, installation, and contributor credit distinct treatment.
+
+Reuse for Lets:
+
+- Frame v0.0.62 as the culmination of changes from v0.0.55.
+- Use before/after terminal output where the key change is clearer behavior or removed ceremony.
+- Keep cumulative statistics secondary to user benefits.
+
+## Cross-project principles
+
+### Lead with the release’s meaning
+
+A good lede answers what shipped, what the unifying benefit is, and what range the article covers. Avoid opening with repository activity, a commit count, or a chronological recital of intermediate versions.
+
+### Use progressive disclosure
+
+Serve three reading depths:
+
+1. **Thirty seconds:** title, release thesis, highlights, upgrade command.
+2. **Five minutes:** user-oriented sections with examples.
+3. **Complete audit:** linked changelog, comparison, issues, and documentation.
+
+The announcement should remain useful without pretending to replace the changelog.
+
+### Group by outcomes, not implementation
+
+Use workflow-oriented headings such as clearer task configuration, better command-line feedback, easier composition, and quality-of-life improvements. Do not force headings that are unsupported by the release evidence.
+
+### Make every major section answer five questions
+
+1. What was awkward, impossible, or surprising before?
+2. What changed?
+3. How does the reader use it?
+4. What becomes easier or more reliable?
+5. Are there caveats, behavior changes, or related docs?
+
+Prefer one realistic runnable example over several artificial variants.
+
+### Distinguish evidence from marketing
+
+- Use exact commands, configuration, and observable output from v0.0.62.
+- Link assertions to documentation, issues, tests, or the comparison range.
+- Include performance numbers only with reproducible evidence.
+- Do not call a change breaking, backward-compatible, faster, or safer without evidence.
+
+### Keep small improvements visible
+
+Give quality-of-life changes a compact section where each bullet states the outcome and affected command or area. Avoid raw commit-message wording and vague bullets.
+
+## Recommended Lets v0.0.62 outline
+
+1. Benefit-led title and cumulative release thesis.
+2. Three to five linked highlights.
+3. Verified installation and upgrade commands.
+4. Major workflow improvements, each with a runnable example.
+5. A compact quality-of-life section.
+6. Compatibility and migration notes.
+7. Full changelog and comparison links.
+8. Thanks and an issue-reporting link.
+
+## Editorial checklist
+
+- [ ] The title names v0.0.62 and communicates a benefit or theme.
+- [ ] The opening explicitly says the post covers changes since v0.0.55.
+- [ ] The correct upgrade and installation commands are verified.
+- [ ] Three to five highlights let readers understand the release quickly.
+- [ ] Sections are ordered by user impact, not commit chronology.
+- [ ] Every major claim maps to a change in the v0.0.55–v0.0.62 range.
+- [ ] Every example is runnable and reflects final v0.0.62 syntax and output.
+- [ ] Before/after examples are used where they clarify removed friction.
+- [ ] Quality-of-life changes have a named section.
+- [ ] Behavioral changes, deprecations, platform requirements, and experimental status are explicit.
+- [ ] Performance claims include reproducible evidence or are omitted.
+- [ ] The article links to the full release notes or repository comparison.

--- a/lets.yaml
+++ b/lets.yaml
@@ -142,6 +142,6 @@ commands:
     work_dir: docs
     cmd: npm run doc:deploy
 
-  run-docs:
+  docs:
     work_dir: docs
-    cmd: npm start
+    cmd: npm install && npm start


### PR DESCRIPTION
## Summary by Sourcery

Add documentation content for the Lets 0.0.63 release, including a release announcement and supporting editorial research, and update the docs command in the task runner configuration.

Enhancements:
- Update the docs task in the lets.yaml configuration to run npm install before starting the documentation site and rename the command to `docs`.

Documentation:
- Add a detailed Lets 0.0.63 release announcement blog post covering new features, upgrade paths, and workflow improvements since v0.0.55.
- Add a research document outlining patterns and recommendations for clear release announcements for Lets v0.0.62.